### PR TITLE
Web server handling pre compressed gzip files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ The web-server configuration is as follows:
         "host", <host>,
         "port", <port>
         "static_files": <static_files>,
-        
-        "ssl": <ssl>,        
+        "gzip_files": <gzip_files>
+
+        "ssl": <ssl>,
         "key_store_password": <key_store_password>,
         "key_store_path": <key_store_path>,
-        
+
         "bridge": <bridge>,
         "inbound_permitted": <inbound_permitted>,
         "outbound_permitted": <outbound_permitted>,
@@ -30,12 +31,13 @@ The web-server configuration is as follows:
         "auth_timeout": <auth_timeout>,
         "auth_address": <auth_address>
     }
-    
+
 * `web_root`. This is the root directory from where files will be served. *Anything that you place here or in sub directories will be externally accessible*. Default is `web`.
 * `index_page`. The page to serve when the root `/` is requested. Default is `index.html`.
 * `host`. The host or ip address to listen at for connections. `0.0.0.0` means listen at all available addresses. Default is `0.0.0.0`.
 * `port`. The port to listen at for connections. Default is `80`.
-* `static_files`. Should the server serve static files? Default is `true`. 
+* `static_files`. Should the server serve static files? Default is `true`.
+* `gzip_files`. Should the server serve pre-compressed files? `true`: check file "fileName.gz", and send it back, if not found, then fallback to "fileName". `false`: send back "fileName", do not check "fileName.gz" unnecessarily. Default is `false`.
 * `ssl`. Should the server use `https` as a protocol? Default is `false`.
 * `key_store_password`. Password of Java keystore which holds the server certificate. Only used if `ssl` is `true`. Default is `wibble`.
 * `key_store_path`. Path to keystore which holds the server certificate. Default is `server-keystore.jks`. Only used if `ssl` is `true`. *Don't put the keystore under your webroot!*.
@@ -44,7 +46,7 @@ The web-server configuration is as follows:
 * `outbound_permitted`. This is an array of JSON objects representing the outbound permitted matches on the bridge. Only used if `bridge` is `true`. See the core manual for a full description of what these are. Defaults to `[]`.
 * `sjs_config`. This is a JSON object representing the configuration of the SockJS bridging application. You'd normally use this for specifying the url at which SockJS will connect to bridge from client side JS to the server. Only used if `bridge` is `true`. Default to `{"prefix": "/eventbus"}`.
 * `auth_timeout`. The bridge can also cache authorisations. This determines how long the bridge will cache one for. Default value is five minutes.
-* `auth_address`. The bridge can also call an authorisation manager to do authorisation. This is the address to which it will send authorisation messages. Default value is `vertx.basicauthmanager.authorise`. 
+* `auth_address`. The bridge can also call an authorisation manager to do authorisation. This is the address to which it will send authorisation messages. Default value is `vertx.basicauthmanager.authorise`.
 
 
 ## Examples
@@ -53,12 +55,12 @@ Here are some examples:
 
 ### Simple static file web server
 
-This serves files from the web directory 
+This serves files from the web directory
 
     {
-        "host": mycompany.com        
+        "host": mycompany.com
     {
-    
+
 ### Simple https server
 
     {
@@ -66,8 +68,8 @@ This serves files from the web directory
         "ssl": true,
         "key_store_path": "mycert.jks",
         "key_store_password": "sausages"
-    }    
-    
+    }
+
 ### Event bus bridge
 
 Pure event bus bridge that doesn't serve static files

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
   vertxProvided("org.vert-x:vertx-core:$vertxVersion")
   vertxProvided("org.vert-x:vertx-platform:$vertxVersion")
 
+  compile "io.netty:netty:$nettyVersion"
+
   testCompile("org.vert-x:vertx-core:$vertxVersion")
   testCompile("org.vert-x:vertx-platform:$vertxVersion")
   testCompile("org.vert-x:vertx-lang-java:$vertxVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,4 @@ vertxGradlePluginVersion=0.1-SNAPSHOT
 
 junitVersion=4.10
 rhinoVersion=1.7R4
+nettyVersion=3.5.0.Final

--- a/src/main/java/org/vertx/mods/WebServer.java
+++ b/src/main/java/org/vertx/mods/WebServer.java
@@ -16,8 +16,10 @@
 
 package org.vertx.mods;
 
+import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.vertx.java.busmods.BusModBase;
 import org.vertx.java.core.Handler;
+import org.vertx.java.core.file.impl.PathAdjuster;
 import org.vertx.java.core.http.HttpServer;
 import org.vertx.java.core.http.HttpServerRequest;
 import org.vertx.java.core.json.JsonArray;
@@ -40,6 +42,7 @@ public class WebServer extends BusModBase implements Handler<HttpServerRequest> 
 
   private String webRootPrefix;
   private String indexPage;
+  private boolean gzipFiles;
 
   public void start() {
     super.start();
@@ -67,6 +70,7 @@ public class WebServer extends BusModBase implements Handler<HttpServerRequest> 
                        getOptionalStringConfig("auth_address", "vertx.basicauthmanager.authorise"));
     }
 
+    gzipFiles = getOptionalBooleanConfig("gzip_files", false);
     String webRoot = getOptionalStringConfig("web_root", "web");
     String index = getOptionalStringConfig("index_page", "index.html");
     webRootPrefix = webRoot + File.separator;
@@ -76,14 +80,32 @@ public class WebServer extends BusModBase implements Handler<HttpServerRequest> 
   }
 
   public void handle(HttpServerRequest req) {
+    // browser gzip capability check
+    String acceptEncoding = req.headers().get(HttpHeaders.Names.ACCEPT_ENCODING);
+    boolean acceptEncodingGzip = acceptEncoding == null ? false : acceptEncoding.contains(HttpHeaders.Values.GZIP);
+
+    String fileName = webRootPrefix + req.path;
     if (req.path.equals("/")) {
       req.response.sendFile(indexPage);
-    } else if (!req.path.contains("src")) {
-      req.response.sendFile(webRootPrefix + req.path);
+    } else if (!req.path.contains("..")) {
+      // try to send *.gz file
+      if (gzipFiles && acceptEncodingGzip) {
+        File file = new File(PathAdjuster.adjust(fileName + ".gz"));
+        if (file.exists()) {
+          // found file with gz extension
+          req.response.putHeader(HttpHeaders.Names.CONTENT_ENCODING, HttpHeaders.Values.GZIP);
+          req.response.sendFile(fileName + ".gz");
+        } else {
+          // not found gz file, try to send uncompressed file
+          req.response.sendFile(fileName);
+        }
+      } else {
+        // send not gzip file
+        req.response.sendFile(fileName);
+      }
     } else {
       req.response.statusCode = 404;
       req.response.end();
     }
   }
 }
-


### PR DESCRIPTION
This modification speed up web server service, with serve smaller pre compressed gz files.
I introduced a new web-server config parameter for speed up execution: gzip_files
"gzip_files": true = check file "fileName.gz", and send it back. If not found, then fallback to "fileName".
"gzip_files": false = send back "fileName", do not check "fileName.gz" unnecessarily. Default is false.
